### PR TITLE
fixes for linux ldap/pam to work with Cronicle

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -787,26 +787,24 @@ module.exports = {
 		if (process.platform === 'linux') {
 			// use /etc/passwd on linux
 			var lines = null;
-			try { lines = fs.readFileSync('/etc/passwd', 'utf8').trim().split(/\n/); }
+			var cols = null;
+			//try { lines = fs.readFileSync('/etc/passwd', 'utf8').trim().split(/\n/); }
+			var opts = { timeout: 1000, encoding: 'utf8', stdio: 'pipe' };
+			try { cols = cp.execSync('/usr/bin/getent passwd | grep ' + username, opts).trim().split(':'); }
 			catch (err) { return null; }
 			
-			for (var idx = 0, len = lines.length; idx < len; idx++) {
-				var cols = lines[idx].trim().split(':');
-				if ((username == cols[0]) || (username == Number(cols[2]))) {
-					user = {
-						username: cols[0],
-						password: cols[1],
-						uid: Number(cols[2]),
-						gid: Number(cols[3]),
-						name: cols[4] && cols[4].split(',')[0],
-						dir: cols[5],
-						shell: cols[6]
-					};
-					idx = len;
-				} // found user
-			} // foreach line
-			
-			if (!user) {
+			if ((username == cols[0]) || (username == Number(cols[2]))) {
+				user = {
+					username: cols[0],
+					password: cols[1],
+					uid: Number(cols[2]),
+					gid: Number(cols[3]),
+					name: cols[4] && cols[4].split(',')[0],
+					dir: cols[5],
+					shell: cols[6]
+				};
+			}
+			else {
 				// user not found
 				return null;
 			}


### PR DESCRIPTION
This fixes the Cronicle issue https://github.com/jhuckaby/Cronicle/issues/141, allowing Cronicle to run as users via ldap/pam. This should work across all linux distros as getent is part of glibc. This was tested on CentOS7. I've included the help for getent below.

# getent --help
Usage: getent [OPTION...] database [key ...]
Get entries from administrative database.

  -i, --no-idn               disable IDN encoding
  -s, --service=CONFIG       Service configuration to be used
  -?, --help                 Give this help list
      --usage                Give a short usage message
  -V, --version              Print program version

Mandatory or optional arguments to long options are also mandatory or optional
for any corresponding short options.

Supported databases:
ahosts ahostsv4 ahostsv6 aliases ethers group gshadow hosts initgroups
netgroup networks passwd protocols rpc services shadow

For bug reporting instructions, please see:
<http://www.gnu.org/software/libc/bugs.html>.